### PR TITLE
epub: Fix index loading for certain documents - look for epub:type

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1199,7 +1199,13 @@ setup_index_from_navfile(gchar *tocpath)
     GList *index = NULL;
     open_xml_document(tocpath);
     set_xml_root_node(NULL);
-    xmlNodePtr nav = xml_get_pointer_to_node((xmlChar*)"nav",(xmlChar*)"id",(xmlChar*)"toc");
+    xmlNodePtr nav = xml_get_pointer_to_node((xmlChar*)"nav",(xmlChar*)"type",(xmlChar*)"toc");
+
+    if (nav == NULL) {
+        xml_free_doc();
+        return NULL;
+    }
+
     xmlretval=NULL;
     xml_parse_children_of_node(nav,(xmlChar*)"ol", NULL,NULL);
     gchar *navdirend = g_strrstr(tocpath,"/");


### PR DESCRIPTION
instead of epub:id.

Add a null check as well.

ref:
https://help.apple.com/itc/booksassetguide/en.lproj/itc0f175a5b9.html#apdd3c4c6d1c0904
https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-nav